### PR TITLE
Tweak generated code to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/
+bin/

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/Kochava/fiftyone-go/fiftyonepattern"
+)
+
+func main() {
+	var (
+		provider fiftyonepattern.Provider = fiftyonepattern.NewProvider("./data/51Degrees-LiteV3.2.dat")
+		match                             = provider.GetMatch("test")
+	)
+
+	fiftyonepattern.DeleteMatch(match)
+
+	fmt.Println("HardwareName: ", match.GetValue("HardwareName"))
+}

--- a/fiftyonepattern/51Degrees.h
+++ b/fiftyonepattern/51Degrees.h
@@ -54,6 +54,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <time.h>
+#include "city.h"
 #ifndef FIFTYONEDEGREES_NO_THREADING
 #include "threading.h"
 #endif

--- a/fiftyonepattern/FiftyOneDegreesPatternV3.go
+++ b/fiftyonepattern/FiftyOneDegreesPatternV3.go
@@ -16,6 +16,8 @@ package fiftyonepattern
 /*
 #cgo LDFLAGS: -lpthread
 #include <time.h>
+
+
 */
 import "C"
 

--- a/fiftyonepattern/FiftyOneDegreesPatternV3.go
+++ b/fiftyonepattern/FiftyOneDegreesPatternV3.go
@@ -16,8 +16,6 @@ package fiftyonepattern
 /*
 #cgo LDFLAGS: -lpthread
 #include <time.h>
-#include "threading.c"
-#include "city.c"
 */
 import "C"
 

--- a/fiftyonetrie/FiftyOneDegreesTrieV3.go
+++ b/fiftyonetrie/FiftyOneDegreesTrieV3.go
@@ -16,8 +16,6 @@ package fiftyonetrie
 /*
 #cgo LDFLAGS: -lpthread
 #include <time.h>
-#include "threading.c"
-#include "../cache.c"
 */
 import "C"
 

--- a/fiftyonetrie/FiftyOneDegreesTrieV3.go
+++ b/fiftyonetrie/FiftyOneDegreesTrieV3.go
@@ -16,6 +16,8 @@ package fiftyonetrie
 /*
 #cgo LDFLAGS: -lpthread
 #include <time.h>
+
+
 */
 import "C"
 

--- a/update.sh
+++ b/update.sh
@@ -44,6 +44,10 @@ sed -i '' 's/package FiftyOneDegreesTrieV3/package fiftyonetrie/' ./fiftyonetrie
 sed -i '' 's/\.\.\/cityhash\///' ./fiftyonepattern/FiftyOneDegreesPatternV3.go fiftyonepattern/51Degrees.*
 sed -i '' 's/\.\.\/threading/threading/' ./fiftyonepattern/51Degrees.* ./fiftyonepattern/FiftyOneDegreesPatternV3.go
 sed -i '' 's/\.\.\/threading/threading/' ./fiftyonetrie/51Degrees.* ./fiftyonetrie/FiftyOneDegreesTriev3.go
+
+sed -i '' 's/#include "city.c"//; s/#include "threading.c"//'  ./fiftyonepattern/FiftyOneDegreesPatternV3.go
+sed -i '' 's/#include "city.c"//; s/#include "threading.c"//; s/#include "\.\.\/cache.c"//'  ./fiftyonetrie/FiftyOneDegreesTrieV3.go
+sed -i '' '56s/^//p; 56s/^.*/#include "city.h"/' ./fiftyonepattern/51Degrees.h
 # sed -i '' 's/\.\.\/cache/cache/' ./fiftyonepattern/*.*
 # sed -i '' 's/\.\.\/cache/cache/' ./fiftyonetrie/*.*
 


### PR DESCRIPTION
Remove includes from .go files -- these aren't used, so we can omit
them, since the .c files are compiled by virtue of being part of the
module (so no need to include them). This can be seen by using `go list
-json` to dump the C, H, etc. files in use by the module.

Add a city.h include to 51Degrees.h, because it requires the city hash
functions from it.